### PR TITLE
Remove logging file - refined redundancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Logging utility tool
  ```
  in the .env file - Logs will be presented in the terminal window.
 
-* To disable debugging set  ```env DEBUG=false ``` in the .env file - logs will be suppressed from the terminal and saved to /logs/All-logs.log.
+* To disable debugging set  ```env DEBUG=false ``` in the .env file
 
 The logging functions are handled by the debugUtility.js
 the four methods for debugging are

--- a/debugUtility.js
+++ b/debugUtility.js
@@ -1,8 +1,5 @@
-const fs = require('fs');// default file system cont module in node.js
-
 const debugKey = process.env.DEBUG; // this variable is set to the
 // environmental DEBUG variable in the .env file.
-const filepath = 'src/logs/all-logs.log';
 
 /** The logger function
 creates an object with the functions err, warn, and debug, Each one of these
@@ -17,79 +14,71 @@ const logger = function JSClass(cont) {
      (let, const, function, class) not yet supported outside strict mode **/
 
   'use strict';
+  if(debugKey){
+    const sep = ':';
+    const clear = '\x1B[0m';// ansi value formats the text color to default
 
-  const sep = ':';
-  const clear = '\x1B[0m';// ansi value formats the text color to default
+    let option;/* this variable is set based on the if statement below.
+    It can either print to the terminal or save to a file.*/
+    let trigger;// this variable is set based on the env DEBUG variable.
+    /** This conditional staement sets the option variable in the logger function
+    equal to either console.log or append.file. **/
 
-  let option;/* this variable is set based on the if statement below.
-  It can either print to the terminal or save to a file.*/
-  let trigger;// this variable is set based on the env DEBUG variable.
-  /** This conditional staement sets the option variable in the logger function
-  equal to either console.log or append.file. **/
-  if (debugKey === 'true') {
-    trigger = 0;
-    option = (a) => { // sets option equal to console.log
-      console.log(a);
+  /** This method is used to log errors in this application **/
+    this.err = (container) => {
+      output('err', container);
     };
-  } else {
-    trigger = 1;
-    option = (a) => {
-      const timeStamp = new Date().toISOString(); // this gets the time and formats
-      // it into a readable format.
-      const front = '{';
-      const sep2 = ',';
-      const end = '}';
-      const data = front + timeStamp + sep2 + a + end; // these variables format
-      // the data saved into the log file.
-      fs.appendFile(filepath, data, (err) => { // this function adds the data
-        // to the log file instead of
-              // overwriting. if a file doesn't exist, this will create one.
-        if (err) throw err;
-      });
+  /** This method is used to log debugs and replases console.logs in this application **/
+    this.debug = (container) => {
+      output('debug', container);
     };
-    console.log('Application Version: ' + process.env.Version);
+  /** This method is used to log warnings in this application **/
+    this.warn = (container) => {
+      output('warn', container);
+    };
+
+    this.log = (container) => {
+      output('log', container);
+    };
   }
-
-/** This method is used to log errors in this application **/
-  this.err = (container) => {
-    const color = '\x1B[31m'; // ansi value formats the text color to red
-    const tag = 'Error!: ';
-    const message = container;
-    if (trigger === 0) {
-      option(color + tag + message + clear);
-    } else if (trigger === 1) {
-      option(tag + sep + cont);
-    }
-  };
-/** This method is used to log debugs and replases console.logs in this application **/
-  this.debug = (container) => {
-    const color = '\x1B[34m'; // ansi value formats the text color to blue
-    const tag = 'Debug';
-    const message = container;
-    if (trigger === 0) {
-      option(color + tag + clear + sep + message);
-    } else if (trigger === 1) {
-      option(tag + sep + cont);
-    }
-  };
-/** This method is used to log warnings in this application **/
-  this.warn = (container) => {
-    const color = '\x1B[41m\x1B[33m'; // ansi value formats the text color to yellow with red background
-    const tag = ' Warning ';
-    const message = container;
-    if (trigger === 0) {
-      option(color + tag + clear + sep + message);
-    } else if (trigger === 1) {
-      option(tag + sep + cont);
-    }
-  };
-
-  this.log = (container) => {
-    const message = container;
-    console.log(message);
-  };
 };
 
+
+function output(type, msgInput){
+  let sep = ':';
+  const clear = '\x1B[0m';// ansi value formats the text color to default
+  let color = '';
+  let tag = '';
+  let outputMethod;
+
+  switch (type){
+    case 'warn':
+      color = '\x1B[41m\x1B[33m'; // ansi value formats the text color to yellow with red background
+      tag = ' Warning ';
+      outputMethod = console.warn;
+      break;
+
+    case 'debug':
+      color = '\x1B[34m'; // ansi value formats the text color to blue
+      tag = ' Debug ';
+      outputMethod = console.log;
+
+      break;
+    case 'err':
+      color = '\x1B[31m'; // ansi value formats the text color to red
+      tag = ' Error ';
+      outputMethod = console.error;
+      break;
+    default:
+      // No current modification for logs / other cases
+      sep = ''; // no seperator for basic logging
+      outputMethod = console.log;
+      break;
+  }
+      const msgOutput = color + tag + clear + sep + msgInput;
+      outputMethod(msgOutput);
+
+}
 
 /** This creates a version of logger and exports it to the application **/
 const debugUtility = new logger();


### PR DESCRIPTION
I brought the logger into requirements with a 12 factor app and am now exclusively using the event stream. (Not log files)

Also, I removed some redundant code and created the output function that concisely preforms the actions that were replicated in several sections.